### PR TITLE
1059 update flux helm release api to v1alpha2

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ To record that you want a chart release, you create a resource of the kind `Flux
 ### Example
 ```
 ---
-apiVersion: helm.integrations.flux.weave.works/v1alpha
+apiVersion: helm.integrations.flux.weave.works/v1alpha2
 kind: FluxHelmRelease
 metadata:
   name: mongodb

--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ spec:
   chartGitPath: mongodb
   releaseName: mongo-database
   values:
-    - name: image
-      value: bitnami/mongodb:3.7.1-r1
-    - name: imagePullPolicy
-      value: IfNotPresent
+    image: bitnami/mongodb:3.7.1-r1
+    imagePullPolicy: IfNotPresent
+    persistence:
+      enabled: false
 ```
 
  - the `name` is mandatory and needs to follow k8s naming conventions

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Helm integration has three parts:
 | helm integration part                   | purpose                       |
 |------------------------|-------------------------------|
 | CustomResourceDefinition for bespoke custom resources | Custom resources (CR) provide chart release configuration/desired state |
-| Flux agent                                            | Monitors chart release configurations and on finding git changes applies CR manifests |
+| Flux agent                                            | Monitors chart release configurations. On finding git changes applies CR manifests |
 | Helm operator                                         | Watches for kubernetes events related to custom resources of FluxHelmRelease kind and acts accordingly on their creation/update/deletion by creating/updating/deleting the relevant release. Also monitors the repo’s charts path and updates the relevant release(s)|
 
 ## Custom resource
@@ -40,7 +40,7 @@ Helm integration has three parts:
 
  - custom resource (CR) name is arbitrary (needs to follow k8s naming conventions):
  - namespace is optional (default by default). Determines where the CR and the Chart are deployed:
- - If releaseName is not provided, the release name will be created as $namespace-$customResourceName
+  - If releaseName is not provided, the release name will be created as $namespace-$customResourceName
  - labels.chart corresponds to chartGitPath, ie chart name
  - chartGitPath is the chart subdir under the charts path (provided to helm-operator together with the rest of the ). Equivalent to the chart name
  - releaseName: optional. Needs to be provided if there is already a running chart release in the cluster and the user wants Flux to manage it from now on.
@@ -48,9 +48,8 @@ Helm integration has three parts:
 
 ## Prerequisites
 
-* Helm server tiller should be ideally running in the cluster already, though the helm-operator will wait until it does. ** 
-
-* A git repo with the following (required) structure: *
+- *Helm server tiller should be ideally running in the cluster already, though the helm-operator will wait until it does.* 
+- *Git repo with the following (required) structure:*
 
 ```
 gitUser/repoName/charts/chart1# 
@@ -66,11 +65,11 @@ gitUser/repoName/releaseconfig/customResource2.yaml etc
 
 2. Path containing charts (as subdirectories directly under this path) is provided to helm-operator in its deployment manifest
 
-2. Name of either path is configurable:
- - releaseconfig path (containing custom resources manifests) is provided through the Weave Cloud UI (used by flux agent)
- - charts path can be configured through the helm-operator-deployment.yaml (used by helm-operator)
+3. Name of either path is configurable:
+  - releaseconfig path (containing custom resources manifests) is provided through the Weave Cloud UI (used by flux agent)
+  - charts path can be configured in the helm-operator-deployment.yaml (used by helm-operator)
 	
-3. One releaseconfig yaml file can contain multiple custom resource manifests
+4. One releaseconfig yaml file can contain multiple custom resource manifests
 
 ## User setup
 

--- a/README.md
+++ b/README.md
@@ -1,84 +1,95 @@
 # flux-helm-test
-A repository with test data for flux-helm integration
 
-# Helm Integration - alpha
+A repository with example configs for relasing Helm charts via Flux.
+
+# The Helm operator (alpha release)
 
 ## Synopsis
 
-Helm integration provides an extension to Flux (https://github.com/weaveworks/flux) to be able to deal with Helm Chart releases.
-A Chart release is described through a custom resource of a bespoke kubernetes kind. A custom resource contains all that needs to be known to do a Chart release (see Custom resource section). At this stage, Helm charts and chart release configuration need to share one repo.
+The Flux Helm operator provides an extension to Flux
+(https://github.com/weaveworks/flux) to be able to automate Helm Chart
+releases. In other words, given a desired state as a file in git, it
+does `helm install` and `helm upgrade` for you.
 
-Helm integration has three parts:
+A Chart release is described through a
+[Kubernetes custom resource](https://kubernetes.io/docs/concepts/api-extension/custom-resources/). Each
+custom resource contains all that needs to be known to do a Chart
+release. The Flux daemon synchronises these resources from git to the
+cluster, and the Flux Helm operator makes sure Helm charts are
+released as specified in the resources.
 
-| helm integration part                   | purpose                       |
-|------------------------|-------------------------------|
-| CustomResourceDefinition for bespoke custom resources | Custom resources (CR) provide chart release configuration/desired state |
-| Flux agent                                            | Monitors chart release configurations. On finding git changes applies CR manifests |
-| Helm operator                                         | Watches for kubernetes events related to custom resources of FluxHelmRelease kind and acts accordingly on their creation/update/deletion by creating/updating/deleting the relevant release. Also monitors the repo’s charts path and updates the relevant release(s)|
+## Custom resource (`FluxHelmRelease`)
 
-## Custom resource
+To record that you want a chart release, you create a resource of the kind `FluxHelmRelease`.
 
 ### Example
 ```
 ---
-  apiVersion: helm.integrations.flux.weave.works/v1alpha
-  kind: FluxHelmRelease
-  metadata:
-    name: mongodb
-    namespace:  myNamespace
-    labels:
-      chart: mongodb
-  spec:
-    chartGitPath: mongodb
-    releaseName: mongo-database
-    values:
-      - name: image
-        value: bitnami/mongodb:3.7.1-r1
-      - name: imagePullPolicy
-        value: IfNotPresent
+apiVersion: helm.integrations.flux.weave.works/v1alpha
+kind: FluxHelmRelease
+metadata:
+  name: mongodb
+  namespace:  default
+  labels:
+    chart: mongodb
+spec:
+  chartGitPath: mongodb
+  releaseName: mongo-database
+  values:
+    - name: image
+      value: bitnami/mongodb:3.7.1-r1
+    - name: imagePullPolicy
+      value: IfNotPresent
 ```
 
- - custom resource (CR) name is arbitrary (needs to follow k8s naming conventions):
- - namespace is optional (default by default). Determines where the CR and the Chart are deployed:
-  - If releaseName is not provided, the release name will be created as $namespace-$customResourceName
- - labels.chart corresponds to chartGitPath, ie chart name
- - chartGitPath is the chart subdir under the charts path (provided to helm-operator together with the rest of the ). Equivalent to the chart name
- - releaseName: optional. Needs to be provided if there is already a running chart release in the cluster and the user wants Flux to manage it from now on.
- - values are user customizations of default parameter values
+ - the `name` is mandatory and needs to follow k8s naming conventions
+ - the `namespace` is optional. It determines where the resource, and thereby the chart, are created
+ - if the `releaseName` field is not provided, the release name used for Helm will be `$namespace-$name`
+ - the label `chart` is mandatory, and should match the directory containing the chart
+ - `chartGitPath` is the directory containing a chart, given relative to the charts path (provided to the helm-operator)
+ - `values` are user customizations of default parameter values from the chart itself
 
-## Prerequisites
+## Prerequisites and limitations
 
-- *Helm server tiller should be ideally running in the cluster already, though the helm-operator will wait until it does.* 
-- *Git repo with the following (required) structure:*
+- Tiller (the server component of Helm) should be running in the
+  cluster. See
+  [the Helm documentation](https://docs.helm.sh/using_helm/#quickstart)
+  for how to install Helm. The Helm operator alpha will only deal with
+  an unauthenticated Tiller installation (the default).
 
-```
-gitUser/repoName/charts/chart1# 
-gitUser/repoName/charts/chart2 etc
+- You need a git repo with a similar directory structure to this repo
+  (if not this repo). That is, the configuration you want sync'ed by
+  the Flux daemon is in its own subdirectory (e.g., `config/` in this
+  repository), separate to your charts. You must tell Flux to use
+  _only_ that directory, otherwise it will try to sync the charts, and
+  fail.
 
-gitUser/repoName/releaseconfig/customResource1.yaml
-gitUser/repoName/releaseconfig/customResource2.yaml etc
-```
-
-### Note
-
-1. Path with chart release configuration (gitUser/repoName/releaseconfig) is provided in the Weave Cloud GUI
-
-2. Path containing charts (as subdirectories directly under this path) is provided to helm-operator in its deployment manifest
-
-3. Name of either path is configurable:
-  - releaseconfig path (containing custom resources manifests) is provided through the Weave Cloud UI (used by flux agent)
-  - charts path can be configured in the helm-operator-deployment.yaml (used by helm-operator)
-	
-4. One releaseconfig yaml file can contain multiple custom resource manifests
+- The Helm operator alpha only deals with charts in a single git
+  repository, which you supply to it as a command-line argument, along
+  with a parent directory for charts within that repository. In the
+  resources, charts are given relative to the parent directory.
 
 ## User setup
 
-1. A cluster available
-2. Set up helm by running: `helm init`
-3. Make a fork of https://github.com/weaveworks/flux-helm-test
-4. Change the git repo information in the artifacts/weave-helm-operator.yaml to refer to the forked one
-5. Go to Weave Cloud and create an instance
-6. Set up Weave agents by running the provided curl command
-7. Before providing git repo information in the GUI, run the following command locally (from the forked repo root): `kubectl apply -f artifacts/weave-helm-operator.yaml`
-8. Provide git repo information in the Weave Cloud UI
-9. All should be set up and running
+You can fork this repo and use it as the basis for trying out the Helm
+operator alpha. It is best to use a fresh Kubernetes cluster.
+
+ 1. Set up helm by running `helm init`, as in [Helm's installation instructions](https://docs.helm.sh/using_helm/#quickstart).
+ 2. Make a fork of this repository to your own account, and clone it to your computer
+ 3. Change the git URL in artifacts/weave-helm-operator.yaml to refer to your fork
+ 4. Go to [Weave Cloud](https://cloud.weave.works/) and create an instance
+ 5. Set up the Weave agents by running the provided curl command
+
+ 6. Before configuring "Deploy" for your new Weave Cloud instance, run
+    this in the clone to install the Helm operator:
+
+    kubectl apply -f artifacts/
+
+ 7. Now go ahead and set "Deploy" up, giving the git URL of your
+    forked repo, and the path `config/`. You will need to install the deploy key (either using the button, or by copying and pasting), since both the operator and the Flux daemon need it to access your forked git repository.
+
+At this point, you can click through to Explore, wait a bit, and see
+the resources started in the cluster by the charts being released. If
+you make a change in the chart, or a change in the chart release
+resource, and push a commit to your fork, the change will be reflected
+shortly in your cluster.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,78 @@
 # flux-helm-test
 A repository with test data for flux-helm integration
+
+# Helm Integration - alpha stage
+
+## Synopsis
+
+Helm integration provides an extension to Flux to be able to deal with Helm Chart releases.
+A Chart release is described through a custom resource of a bespoke kubernetes kind. A custom resource contains all that needs to be known to do a Chart release (see Custom resource section). At this stage, Helm charts and chart release configuration need to share one repo.
+
+Helm integration has three parts:
+
+| CustomResourceDefinition for bespoke custom resources | Custom resources (CR) provide chart release configuration/desired state |
+| Flux agent                                            | * Monitors chart release configurations and on finding git changes applies CR manifests |
+| Helm operator                                         | * Watches for kubernetes events related to custom resources of FluxHelmRelease kind and acts accordingly on their creation/update/deletion by creating/updating/deleting the relevant release, * It monitors the repo’s charts path and updates the relevant release|
+
+## Custom resource
+
+### Example
+---
+  apiVersion: helm.integrations.flux.weave.works/v1alpha
+  kind: FluxHelmRelease
+  metadata:
+    name: mongodb
+    namespace:  myNamespace
+    labels:
+      chart: mongodb
+  spec:
+    chartGitPath: mongodb
+    releaseName: mongo-database
+    values:
+      - name: image
+        value: bitnami/mongodb:3.7.1-r1
+      - name: imagePullPolicy
+        value: IfNotPresent
+
+custom resource (CR) name is arbitrary (needs to follow k8s naming conventions):
+If releaseName is not provided, the release name will be created as $namespace-$customResourceName
+namespace is optional (default by default). Determines where the CR and the Chart are deployed:
+If releaseName is not provided, the release name will be created as $namespace-$customResourceName
+labels.chart corresponds to chartGitPath
+chartGitPath is the chart subdir under the charts path (provided to helm-operator together with the rest of the )
+Equivalent to the chart name
+releaseName: optional. Needs to be provided if there is already a running chart release in the cluster and the user wants Flux to manage it from now on.
+values are user customizations of default parameter values
+
+## Prerequisites
+
+Helm server tiller should be ideally running in the cluster already, though the helm-operator will wait until it does
+A git repo with the following (required) structure:
+
+gitUser/repoName/charts/chart1# 
+gitUser/repoName/charts/chart2 etc
+
+gitUser/repoName/releaseconfig/customResource1.yaml
+gitUser/repoName/releaseconfig/customResource2.yaml etc
+
+Note
+1. Name of either of the two paths is configurable:
+releaseconfig path (containing custom resources manifests) is provided through the Weave Cloud UI (used by flux agent)
+charts path can be configured through the helm-operator-deployment.yaml (used by helm-operator)
+	
+2. One  releaseconfig yaml file can contain multiple custom resource manifests.
+
+A directory with charts 
+Each subdirectory is checked if it is a valid chart (containing Chart.yaml)
+
+## User setup
+
+1. A cluster available
+2. Set up helm by running: `helm init`
+3. Make a fork of https://github.com/weaveworks/flux-helm-test
+4. Change the git repo information in the artifacts/weave-helm-operator.yaml to refer to the forked one
+5. Go to Weave Cloud and create an instance
+6. Set up Weave agents by running the provided curl command
+7. Before providing git repo information in the GUI, run the following command locally (from the forked repo root): `kubectl apply -f artifacts/weave-helm-operator.yaml`
+8. Provide git repo information in the Weave Cloud UI
+9. All should be set up and running

--- a/README.md
+++ b/README.md
@@ -76,17 +76,21 @@ operator alpha. It is best to use a fresh Kubernetes cluster.
 
  1. Set up helm by running `helm init`, as in [Helm's installation instructions](https://docs.helm.sh/using_helm/#quickstart).
  2. Make a fork of this repository to your own account, and clone it to your computer
- 3. Change the git URL in artifacts/weave-helm-operator.yaml to refer to your fork
+ 3. In your cloned repo, change the git URL in `artifacts/weave-helm-operator.yaml` to refer to your fork on github
  4. Go to [Weave Cloud](https://cloud.weave.works/) and create an instance
  5. Set up the Weave agents by running the provided curl command
 
  6. Before configuring "Deploy" for your new Weave Cloud instance, run
-    this in the clone to install the Helm operator:
+    this in the cloned repository to install the Helm operator:
 
     kubectl apply -f artifacts/
 
- 7. Now go ahead and set "Deploy" up, giving the git URL of your
-    forked repo, and the path `config/`. You will need to install the deploy key (either using the button, or by copying and pasting), since both the operator and the Flux daemon need it to access your forked git repository.
+ 7. Now go back to Weave Cloud and set "Deploy" up, giving the git URL
+    of your forked repo, and the path `config/`. You will need to
+    install the deploy key (either using the button, or by copying and
+    pasting), since both the operator and the Flux daemon need it to
+    access your forked git repository. Run the kubectl command given
+    there to complete the setup.
 
 At this point, you can click through to Explore, wait a bit, and see
 the resources started in the cluster by the charts being released. If

--- a/README.md
+++ b/README.md
@@ -97,3 +97,14 @@ the resources started in the cluster by the charts being released. If
 you make a change in the chart, or a change in the chart release
 resource, and push a commit to your fork, the change will be reflected
 shortly in your cluster.
+
+## <a name="help"></a>Getting Help
+
+If you have any questions about, feedback for or problems with `flux-helm-test`:
+
+- Invite yourself to the <a href="https://weaveworks.github.io/community-slack/" target="_blank"> #weave-community </a> slack channel.
+- Ask a question on the <a href="https://weave-community.slack.com/messages/general/"> #weave-community</a> slack channel.
+- Send an email to <a href="mailto:weave-users@weave.works">weave-users@weave.works</a>
+- <a href="https://github.com/weaveworks/flux-helm-test/issues/new">File an issue.</a>
+
+Your feedback is always welcome!

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # flux-helm-test
 A repository with test data for flux-helm integration
 
-# Helm Integration - alpha stage
+# Helm Integration - alpha
 
 ## Synopsis
 
-Helm integration provides an extension to Flux to be able to deal with Helm Chart releases.
+Helm integration provides an extension to Flux (https://github.com/weaveworks/flux) to be able to deal with Helm Chart releases.
 A Chart release is described through a custom resource of a bespoke kubernetes kind. A custom resource contains all that needs to be known to do a Chart release (see Custom resource section). At this stage, Helm charts and chart release configuration need to share one repo.
 
 Helm integration has three parts:

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ A Chart release is described through a custom resource of a bespoke kubernetes k
 
 Helm integration has three parts:
 
-| part                   | purpose                       |
+| helm integration part                   | purpose                       |
 |------------------------|-------------------------------|
 | CustomResourceDefinition for bespoke custom resources | Custom resources (CR) provide chart release configuration/desired state |
-| Flux agent                                            | * Monitors chart release configurations and on finding git changes applies CR manifests |
-| Helm operator                                         | * Watches for kubernetes events related to custom resources of FluxHelmRelease kind and acts accordingly on their creation/update/deletion by creating/updating/deleting the relevant release, * It monitors the repo’s charts path and updates the relevant release|
+| Flux agent                                            | Monitors chart release configurations and on finding git changes applies CR manifests |
+| Helm operator                                         | Watches for kubernetes events related to custom resources of FluxHelmRelease kind and acts accordingly on their creation/update/deletion by creating/updating/deleting the relevant release. Also monitors the repo’s charts path and updates the relevant release(s)|
 
 ## Custom resource
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ operator alpha. It is best to use a fresh Kubernetes cluster.
     kubectl apply -f artifacts/
 
  7. Now go back to Weave Cloud and set "Deploy" up, giving the git URL
-    of your forked repo, and the path `config/`. You will need to
+    of your forked repo, and the path `config`. You will need to
     install the deploy key (either using the button, or by copying and
     pasting), since both the operator and the Flux daemon need it to
     access your forked git repository. Run the kubectl command given

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ A Chart release is described through a custom resource of a bespoke kubernetes k
 
 Helm integration has three parts:
 
+| part                   | purpose                       |
+|------------------------|-------------------------------|
 | CustomResourceDefinition for bespoke custom resources | Custom resources (CR) provide chart release configuration/desired state |
 | Flux agent                                            | * Monitors chart release configurations and on finding git changes applies CR manifests |
 | Helm operator                                         | * Watches for kubernetes events related to custom resources of FluxHelmRelease kind and acts accordingly on their creation/update/deletion by creating/updating/deleting the relevant release, * It monitors the repo’s charts path and updates the relevant release|
@@ -17,6 +19,7 @@ Helm integration has three parts:
 ## Custom resource
 
 ### Example
+```
 ---
   apiVersion: helm.integrations.flux.weave.works/v1alpha
   kind: FluxHelmRelease
@@ -33,37 +36,41 @@ Helm integration has three parts:
         value: bitnami/mongodb:3.7.1-r1
       - name: imagePullPolicy
         value: IfNotPresent
+```
 
-custom resource (CR) name is arbitrary (needs to follow k8s naming conventions):
-If releaseName is not provided, the release name will be created as $namespace-$customResourceName
-namespace is optional (default by default). Determines where the CR and the Chart are deployed:
-If releaseName is not provided, the release name will be created as $namespace-$customResourceName
-labels.chart corresponds to chartGitPath
-chartGitPath is the chart subdir under the charts path (provided to helm-operator together with the rest of the )
-Equivalent to the chart name
-releaseName: optional. Needs to be provided if there is already a running chart release in the cluster and the user wants Flux to manage it from now on.
-values are user customizations of default parameter values
+ - custom resource (CR) name is arbitrary (needs to follow k8s naming conventions):
+ - namespace is optional (default by default). Determines where the CR and the Chart are deployed:
+ - If releaseName is not provided, the release name will be created as $namespace-$customResourceName
+ - labels.chart corresponds to chartGitPath, ie chart name
+ - chartGitPath is the chart subdir under the charts path (provided to helm-operator together with the rest of the ). Equivalent to the chart name
+ - releaseName: optional. Needs to be provided if there is already a running chart release in the cluster and the user wants Flux to manage it from now on.
+ - values are user customizations of default parameter values
 
 ## Prerequisites
 
-Helm server tiller should be ideally running in the cluster already, though the helm-operator will wait until it does
-A git repo with the following (required) structure:
+* Helm server tiller should be ideally running in the cluster already, though the helm-operator will wait until it does. ** 
 
+* A git repo with the following (required) structure: *
+
+```
 gitUser/repoName/charts/chart1# 
 gitUser/repoName/charts/chart2 etc
 
 gitUser/repoName/releaseconfig/customResource1.yaml
 gitUser/repoName/releaseconfig/customResource2.yaml etc
+```
 
-Note
-1. Name of either of the two paths is configurable:
-releaseconfig path (containing custom resources manifests) is provided through the Weave Cloud UI (used by flux agent)
-charts path can be configured through the helm-operator-deployment.yaml (used by helm-operator)
+### Note
+
+1. Path with chart release configuration (gitUser/repoName/releaseconfig) is provided in the Weave Cloud GUI
+
+2. Path containing charts (as subdirectories directly under this path) is provided to helm-operator in its deployment manifest
+
+2. Name of either path is configurable:
+ - releaseconfig path (containing custom resources manifests) is provided through the Weave Cloud UI (used by flux agent)
+ - charts path can be configured through the helm-operator-deployment.yaml (used by helm-operator)
 	
-2. One  releaseconfig yaml file can contain multiple custom resource manifests.
-
-A directory with charts 
-Each subdirectory is checked if it is a valid chart (containing Chart.yaml)
+3. One releaseconfig yaml file can contain multiple custom resource manifests
 
 ## User setup
 

--- a/artifacts/fluxhelmreleases-crd.yaml
+++ b/artifacts/fluxhelmreleases-crd.yaml
@@ -1,0 +1,13 @@
+---
+  apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: fluxhelmreleases.helm.integrations.flux.weave.works
+  spec:
+    group: helm.integrations.flux.weave.works
+    names:
+      kind: FluxHelmRelease
+      listKind: FluxHelmReleaseList
+      plural: fluxhelmreleases
+    scope: Namespaced
+    version: v1alpha               

--- a/artifacts/fluxhelmreleases-crd.yaml
+++ b/artifacts/fluxhelmreleases-crd.yaml
@@ -1,13 +1,13 @@
 ---
-  apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    name: fluxhelmreleases.helm.integrations.flux.weave.works
-  spec:
-    group: helm.integrations.flux.weave.works
-    names:
-      kind: FluxHelmRelease
-      listKind: FluxHelmReleaseList
-      plural: fluxhelmreleases
-    scope: Namespaced
-    version: v1alpha               
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: fluxhelmreleases.helm.integrations.flux.weave.works
+spec:
+  group: helm.integrations.flux.weave.works
+  names:
+    kind: FluxHelmRelease
+    listKind: FluxHelmReleaseList
+    plural: fluxhelmreleases
+  scope: Namespaced
+  version: v1alpha               

--- a/artifacts/weave-helm-operator.yaml
+++ b/artifacts/weave-helm-operator.yaml
@@ -1,0 +1,58 @@
+---
+  apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
+  metadata:
+    name: fluxhelmreleases.helm.integrations.flux.weave.works
+  spec:
+    group: helm.integrations.flux.weave.works
+    names:
+      kind: FluxHelmRelease
+      listKind: FluxHelmReleaseList
+      plural: fluxhelmreleases
+    scope: Namespaced
+    version: v1alpha               
+---
+  apiVersion: apps/v1beta1
+  kind: Deployment
+  metadata:
+    name: weave-flux-helm-operator
+    labels:
+      name: weave-flux-helm-operator
+      app: weave-flux
+      weave-cloud-component: flux
+      weave-flux-component: helm-operator
+    namespace: weave
+  spec:
+    replicas: 1
+    strategy:
+      type: Recreate
+    template:
+      metadata:
+        labels:
+          name: weave-flux-helm-operator
+          app: weave-flux
+          weave-cloud-component: flux
+          weave-flux-component: helm-operator
+      spec:
+        containers:
+          - name: flux-helm-operator
+            args:
+              - '--git-url=git@github.com:weaveworks/flux-helm-test.git'
+              - '--git-branch=master'
+              - '--git-charts-path=charts'
+            env:
+              - name: WEAVE_CLOUD_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: weave-cloud
+                    key: token
+            image: 'quay.io/weaveworks/helm-operator:alpha'
+            imagePullPolicy: IfNotPresent
+            volumeMounts:
+              - name: git-key
+                mountPath: /etc/fluxd/ssh
+        serviceAccountName: weave-flux
+        volumes:
+          - name: git-key
+            secret:
+              secretName: flux-git-deploy 

--- a/artifacts/weave-helm-operator.yaml
+++ b/artifacts/weave-helm-operator.yaml
@@ -1,45 +1,40 @@
 ---
-  apiVersion: apps/v1beta1
-  kind: Deployment
-  metadata:
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: weave-flux-helm-operator
+  labels:
     name: weave-flux-helm-operator
-    labels:
-      name: weave-flux-helm-operator
-      app: weave-flux
-      weave-cloud-component: flux
-      weave-flux-component: helm-operator
-    namespace: weave
-  spec:
-    replicas: 1
-    strategy:
-      type: Recreate
-    template:
-      metadata:
-        labels:
-          name: weave-flux-helm-operator
-          app: weave-flux
-          weave-cloud-component: flux
-          weave-flux-component: helm-operator
-      spec:
-        serviceAccount: weave-flux
-        containers:
-          - name: flux-helm-operator
-            args:
-              - '--git-url=git@github.com:weaveworks/flux-helm-test.git'
-              - '--git-branch=master'
-              - '--git-charts-path=charts'
-            env:
-              - name: WEAVE_CLOUD_TOKEN
-                valueFrom:
-                  secretKeyRef:
-                    name: weave-cloud
-                    key: token
-            image: 'quay.io/weaveworks/helm-operator:alpha'
-            imagePullPolicy: IfNotPresent
-            volumeMounts:
-              - name: git-key
-                mountPath: /etc/fluxd/ssh
-        volumes:
-          - name: git-key
-            secret:
-              secretName: flux-git-deploy 
+    app: weave-flux
+    weave-cloud-component: flux
+    weave-flux-component: helm-operator
+  namespace: weave
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        name: weave-flux-helm-operator
+        app: weave-flux
+        weave-cloud-component: flux
+        weave-flux-component: helm-operator
+    spec:
+      volumes:
+      - name: git-key
+        secret:
+          secretName: flux-git-deploy
+      serviceAccountName: weave-flux
+      containers:
+      - name: weave-flux-helm-operator
+        image: 'quay.io/weaveworks/helm-operator:alpha'
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - name: git-key
+          mountPath: /etc/fluxd/ssh
+        args:
+        # replace (at least) the following URL
+        - '--git-url=git@github.com:weaveworks/flux-helm-test.git'
+        - '--git-branch=master'
+        - '--git-charts-path=charts'

--- a/artifacts/weave-helm-operator.yaml
+++ b/artifacts/weave-helm-operator.yaml
@@ -1,17 +1,4 @@
 ---
-  apiVersion: apiextensions.k8s.io/v1beta1
-  kind: CustomResourceDefinition
-  metadata:
-    name: fluxhelmreleases.helm.integrations.flux.weave.works
-  spec:
-    group: helm.integrations.flux.weave.works
-    names:
-      kind: FluxHelmRelease
-      listKind: FluxHelmReleaseList
-      plural: fluxhelmreleases
-    scope: Namespaced
-    version: v1alpha               
----
   apiVersion: apps/v1beta1
   kind: Deployment
   metadata:
@@ -34,6 +21,7 @@
           weave-cloud-component: flux
           weave-flux-component: helm-operator
       spec:
+        serviceAccount: weave-flux
         containers:
           - name: flux-helm-operator
             args:
@@ -51,7 +39,6 @@
             volumeMounts:
               - name: git-key
                 mountPath: /etc/fluxd/ssh
-        serviceAccountName: weave-flux
         volumes:
           - name: git-key
             secret:

--- a/config/mariadb_release.yaml
+++ b/config/mariadb_release.yaml
@@ -1,5 +1,5 @@
 ---
-  apiVersion: helm.integrations.flux.weave.works/v1alpha
+  apiVersion: helm.integrations.flux.weave.works/v1alpha2
   kind: FluxHelmRelease
   metadata:
     name: mariadb

--- a/config/mariadb_release.yaml
+++ b/config/mariadb_release.yaml
@@ -3,7 +3,7 @@
   kind: FluxHelmRelease
   metadata:
     name: mariadb
-    namespace: kube-system
+    namespace: default
     labels:
       chart: mariadb
   spec:
@@ -11,4 +11,5 @@
     values:
       - name: image
         value: bitnami/mariadb:10.1.30-r1
-
+      - name: persistence.enabled
+        value: false

--- a/config/mariadb_release.yaml
+++ b/config/mariadb_release.yaml
@@ -9,7 +9,6 @@
   spec:
     chartGitPath: mariadb
     values:
-      - name: image
-        value: bitnami/mariadb:10.1.30-r1
-      - name: persistence.enabled
-        value: "false"
+      image: bitnami/mariadb:10.1.30-r1
+      persistence:
+        enabled: false

--- a/config/mariadb_release.yaml
+++ b/config/mariadb_release.yaml
@@ -12,4 +12,4 @@
       - name: image
         value: bitnami/mariadb:10.1.30-r1
       - name: persistence.enabled
-        value: false
+        value: "false"

--- a/config/mongodb_release.yaml
+++ b/config/mongodb_release.yaml
@@ -1,5 +1,5 @@
 ---
-  apiVersion: helm.integrations.flux.weave.works/v1alpha
+  apiVersion: helm.integrations.flux.weave.works/v1alpha2
   kind: FluxHelmRelease
   metadata:
     name: mongodb

--- a/config/mongodb_release.yaml
+++ b/config/mongodb_release.yaml
@@ -10,9 +10,7 @@
     chartGitPath: mongodb
     releaseName: mongodb-database
     values:
-      - name: image
-        value: bitnami/mongodb:3.7.1-r1
-      - name: imagePullPolicy
-        value: IfNotPresent
-      - name: persistence.enabled
-        value: "false"
+      image: bitnami/mongodb:3.7.1-r1
+      imagePullPolicy: IfNotPresent
+      persistence:
+        enabled: false

--- a/config/mongodb_release.yaml
+++ b/config/mongodb_release.yaml
@@ -3,15 +3,16 @@
   kind: FluxHelmRelease
   metadata:
     name: mongodb
-    namespace: kube-system
+    namespace: default
     labels:
       chart: mongodb
   spec:
     chartGitPath: mongodb
-    releaseName: kube-system-mongodb
+    releaseName: mongodb-database
     values:
       - name: image
         value: bitnami/mongodb:3.7.1-r1
       - name: imagePullPolicy
         value: IfNotPresent
-            
+      - name: persistence.enabled
+        value: false

--- a/config/mongodb_release.yaml
+++ b/config/mongodb_release.yaml
@@ -15,4 +15,4 @@
       - name: imagePullPolicy
         value: IfNotPresent
       - name: persistence.enabled
-        value: false
+        value: "false"


### PR DESCRIPTION
Reasons:

- Incorrect initial API version, inconsistent with the Kubernetes one
- Breaking change in the FluxHelmRelease schema
(#1035)

Note:
Main changes made in the flux codebase (https://github.com/weaveworks/flux/pull/1061)